### PR TITLE
Fix bad typespec

### DIFF
--- a/lib/client.ex
+++ b/lib/client.ex
@@ -483,7 +483,7 @@ defmodule ExAlipay.Client do
   @doc """
   Verify the sign of alipay notify, used in handler of notify_url.
   """
-  @spec verify_notify_sign?(Client.t(), Map.t()) :: boolean
+  @spec verify_notify_sign?(Client.t(), map()) :: boolean
   def verify_notify_sign?(client, body) do
     {sign, body} = Map.pop(body, :sign)
     {sign_type, body} = Map.pop(body, :sign_type)


### PR DESCRIPTION
When using dialyzer, it always raises the following error:
```
The function call will not succeed.

ExAlipay.Client.verify_notify_sign?(
  %ExAlipay.Client{
    :appid => _,
    :charset => <<_::40>>,
    :format => <<_::32>>,
    :pid => nil,
    :private_key => <<_::64, _::size(8)>>,
    :public_key => <<_::64, _::size(8)>>,
    :sandbox? => false,
    :sign_type => <<_::32>>,
    :version => <<_::24>>
  },
  _body :: map()
)

breaks the contract
(t(), Map.t()) :: boolean()
```

The reason is that `Map.t()` is not a valid type, but `map()` is.

This PR aims to fix this problem.

---
If you are willing to merge this PR, please also consider to publish a new version on Hex.pm, so that everyone can benefit from this change. ;)
